### PR TITLE
fix mistyped return type in code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ func main() {
 	}
 	var output []string
 
-	godash.Filter(input, &output, func(person Person) string {
+	godash.Filter(input, &output, func(person Person) bool {
 		return person.Age > 25
 	})
 


### PR DESCRIPTION
In a readme code block, incorrect return type is mentioned. It is fixed as part of this commit.